### PR TITLE
chore: use personal access token for release-please 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-release: true


### PR DESCRIPTION
this is necessary in order for release-please actions to trigger other GitHub actions